### PR TITLE
30260 developer not able to set moreAvailable

### DIFF
--- a/Source/ChartIQScriptManager.swift
+++ b/Source/ChartIQScriptManager.swift
@@ -631,7 +631,7 @@ internal class ChartIQScriptManager: ChartIQScriptManagerProtocol {
   ///   - json: The String Object.
   ///   - cb: The String Object.
   /// - Returns: The String Object that contains a JS script for evaluate in the WebView.
-  internal func getScriptForFormatJSQuoteData(_ json: String, cb: String) -> String {
+  internal func getScriptForFormatJSQuoteData(_ json: String, moreAvailable: Bool, cb: String) -> String {
     let script = mobileNameSpace + "parseData('\(json)', \"\(cb)\");"
     return script
   }

--- a/Source/ChartIQScriptManager.swift
+++ b/Source/ChartIQScriptManager.swift
@@ -632,7 +632,7 @@ internal class ChartIQScriptManager: ChartIQScriptManagerProtocol {
   ///   - cb: The String Object.
   /// - Returns: The String Object that contains a JS script for evaluate in the WebView.
   internal func getScriptForFormatJSQuoteData(_ json: String, moreAvailable: Bool, cb: String) -> String {
-    let script = mobileNameSpace + "parseData('\(json)', \"\(cb)\");"
+    let script = mobileNameSpace + "parseData('\(json)', \"\(cb)\", \(moreAvailable));"
     return script
   }
 

--- a/Source/ChartIQScriptManagerProtocol.swift
+++ b/Source/ChartIQScriptManagerProtocol.swift
@@ -392,7 +392,7 @@ internal protocol ChartIQScriptManagerProtocol {
   ///   - json: The String Object.
   ///   - cb: The String Object.
   /// - Returns: The String Object that contains a JS script for evaluate in the WebView.
-  func getScriptForFormatJSQuoteData(_ json: String, cb: String) -> String
+  func getScriptForFormatJSQuoteData(_ json: String, moreAvailable: Bool, cb: String) -> String
 
   /// Returns a script that gets a drawing listener.
   ///

--- a/Source/ChartIQView.swift
+++ b/Source/ChartIQView.swift
@@ -923,7 +923,7 @@ extension ChartIQView: WKScriptMessageHandler {
         // By default if the last pagination request return 0 data then it has probably reached the end.
         // If you have spotty data then another idea might be to check the last historical date, this would require you knowing what date to stop at though.
         var moreAvailable = true
-        if(data.count < 1000) {
+        if(data.count < 1) {
             moreAvailable = false
         }
         self.formatJSQuoteData(data, moreAvailable: moreAvailable, cb: cb)


### PR DESCRIPTION
The ability to set the `moreAvailable` flag for the quotefeed has been added. 

A couple of approaches were considered before the final version. One was to add the `moreAvailable` boolean to the data being sent to the native quotefeed functions. This proved to be difficult as the loadData method is agnostic and doesn't really know what quotefeed function is calling it. 

Another approach was to add the `moreAvailable` flag to the JSON that is created when converting the array of data. This also proved to be clunky and hack-ish in my opinion. The end result was splicing strings together and we are trying to avoid that in the new SDK. An idea of creating a class that will combine both the array of data and boolean into a JSON string was considered, but the solution implemented is simple enough and I'd have to pick CodeIT's brain a bit. No time to do that at the moment. 

In the end adding the `moreAvailable` check in the individual quotefeed methods will do the trick and the user can modify them if needed. 

To test deploy the branch in PR https://github.com/ChartIQ/stx/pull/2487 and open this branch in XCode. Change the `chartIQURL` in ChartIQApp/Constants/Const.swift and deploy the emulator. 