### PR TITLE
Bump project to 3.1.0

### DIFF
--- a/Demo/ChartIQDemo.xcodeproj/project.pbxproj
+++ b/Demo/ChartIQDemo.xcodeproj/project.pbxproj
@@ -1482,15 +1482,15 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1.0;
-				DEVELOPMENT_TEAM = XPJG98X97P;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 8TPE6S3AGR;
 				INFOPLIST_FILE = "$(SRCROOT)/ChartIQDemo/Supporting Files/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.0;
+				MARKETING_VERSION = 3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.chartiq.TechnicalAnalysisChart;
 				PRODUCT_MODULE_NAME = ChartIQDemo;
 				PRODUCT_NAME = ChartIQDemo;
@@ -1506,15 +1506,15 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1.0;
-				DEVELOPMENT_TEAM = XPJG98X97P;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 8TPE6S3AGR;
 				INFOPLIST_FILE = "$(SRCROOT)/ChartIQDemo/Supporting Files/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.0;
+				MARKETING_VERSION = 3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.chartiq.TechnicalAnalysisChart;
 				PRODUCT_MODULE_NAME = ChartIQDemo;
 				PRODUCT_NAME = ChartIQDemo;

--- a/Demo/SharedDemo/Constants/Const.swift
+++ b/Demo/SharedDemo/Constants/Const.swift
@@ -39,7 +39,7 @@ public struct Const {
   // MARK: - General
 
   struct General {
-    static let chartIQURL = "https://mobile.demo.chartiq.com/ios/3.0.0/sample-template-native-sdk.html"
+    static let chartIQURL = "https://mobile.demo.chartiq.com/ios/3.1.0/sample-template-native-sdk.html"
 
     static let cancelTitle = "Cancel"
     static let clearTitle = "Clear"


### PR DESCRIPTION
- Charting library url change
- The Team ID change I think is for ChartIQ LLC team that I use for the
upload to the store.