### PR TITLE
47007 Add target property for not using non-exempt encryption

### DIFF
--- a/Demo/ChartIQDemo/Supporting Files/Info.plist
+++ b/Demo/ChartIQDemo/Supporting Files/Info.plist
@@ -20,6 +20,8 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>


### PR DESCRIPTION
https://cosaic.kanbanize.com/ctrl_board/15/cards/47007/details/

The apple store docs recommend adding this target property to the project to indicate that it doesn't not use non-exempt encryption. https://developer.apple.com/documentation/security/complying_with_encryption_export_regulations