### PR TITLE
Refactor addStudy for iOS

### DIFF
--- a/Source/ChartIQScriptManager.swift
+++ b/Source/ChartIQScriptManager.swift
@@ -484,13 +484,14 @@ internal class ChartIQScriptManager: ChartIQScriptManagerProtocol {
   /// Returns a script that adds a study.
   ///
   /// - Parameters:
-  ///   - studyName: The String Object.
-  ///   - studyInputs: The String Object.
-  ///   - studyOutputs: The String Object.
+  ///   - studyName: The String Object of the study name.
+  ///   - studyInputs: The JSON String Object of the study inputs
+  ///   - studyOutputs: The JSON String Object of the study outputs.
+  ///   - studyParameters: The JSON String Object of the study parameters.
   /// - Returns: The String Object that contains a JS script for evaluate in the WebView.
-  internal func getScriptForAddStudy(_ studyName: String, studyInputs: String, studyOutputs: String) -> String {
+  internal func getScriptForAddStudy(_ studyName: String, studyInputs: String, studyOutputs: String, studyParameters: String) -> String {
     let safeStudyName = safeScriptParameter(studyName)
-    let script = mobileBridgeNameSpace + ".addStudy('\(safeStudyName)', \(studyInputs), \(studyOutputs));"
+    let script = mobileBridgeNameSpace + ".addStudy('\(safeStudyName)', \(studyInputs), \(studyOutputs), \(studyParameters));"
     return script
   }
 

--- a/Source/ChartIQScriptManagerProtocol.swift
+++ b/Source/ChartIQScriptManagerProtocol.swift
@@ -298,11 +298,12 @@ internal protocol ChartIQScriptManagerProtocol {
   /// Returns a script that adds a study.
   ///
   /// - Parameters:
-  ///   - studyName: The String Object.
-  ///   - studyInputs: The String Object.
-  ///   - studyOutputs: The String Object.
+  ///   - studyName: The String Object of the study name.
+  ///   - studyInputs: The JSON String Object of the study inputs
+  ///   - studyOutputs: The JSON String Object of the study outputs.
+  ///   - studyParameters: The JSON String Object of the study parameters.
   /// - Returns: The String Object that contains a JS script for evaluate in the WebView.
-  func getScriptForAddStudy(_ studyName: String, studyInputs: String, studyOutputs: String) -> String
+  func getScriptForAddStudy(_ studyName: String, studyInputs: String, studyOutputs: String, studyParameters: String) -> String
 
   /// Returns a script that removes a study.
   ///

--- a/Source/ChartIQView.swift
+++ b/Source/ChartIQView.swift
@@ -576,7 +576,12 @@ public class ChartIQView: UIView {
     let studyName = forClone ? study.originalName : study.shortName
     var studyInputs = Const.Study.nullParam
     var studyOutputs = Const.Study.nullParam
-    if let inputs = inputs,
+
+    var test = inputs
+    var _ = forClone ? test?.updateValue("id", forKey: "") : ""
+    if var inputs = inputs,
+       // change the id so the study can be cloned and not just updated
+       var _ = forClone ? inputs.updateValue("id", forKey: "") : "",
        let jsonData = try? JSONSerialization.data(withJSONObject: inputs, options: .prettyPrinted),
        let jsonString = String(data: jsonData, encoding: .utf8) {
       studyInputs = jsonString

--- a/Source/ChartIQView.swift
+++ b/Source/ChartIQView.swift
@@ -565,36 +565,36 @@ public class ChartIQView: UIView {
   ///
   /// - Parameters:
   ///   - study: The ChartIQStudy model.
-  ///   - forClone: The Bool value indicating whether a study will be added for cloning or for adding.
-  ///   - inputs: Inputs for the study instance. If nil, it will use the paramters defined in CIQ.Studies.DialogHelper.
-  ///   - outputs: Outputs for the study instance. If nil, it will use the paramters defined in CIQ.Studies.DialogHelper.
+  ///   - forClone: The Bool value indicating whether a study will be added or cloned.
   /// - Throws: ChartIQStudyError.
   public func addStudy(_ study: ChartIQStudy,
-                       forClone: Bool = false,
-                       inputs: [String: Any]? = nil,
-                       outputs: [String: Any]? = nil) throws {
+                       forClone: Bool = false) throws {
     let studyName = forClone ? study.originalName : study.shortName
     var studyInputs = Const.Study.nullParam
     var studyOutputs = Const.Study.nullParam
+    var studyParameters = Const.Study.nullParam
 
-    var test = inputs
-    var _ = forClone ? test?.updateValue("id", forKey: "") : ""
-    if var inputs = inputs,
+    if var inputs = study.inputs,
        // change the id so the study can be cloned and not just updated
-       var _ = forClone ? inputs.updateValue("id", forKey: "") : "",
+       var _ = forClone ? inputs.updateValue("", forKey: "id") : "",
        let jsonData = try? JSONSerialization.data(withJSONObject: inputs, options: .prettyPrinted),
        let jsonString = String(data: jsonData, encoding: .utf8) {
       studyInputs = jsonString
     }
-    if let outputs = outputs,
+    if let outputs = study.outputs,
        let jsonData = try? JSONSerialization.data(withJSONObject: outputs, options: .prettyPrinted),
        let jsonString = String(data: jsonData, encoding: .utf8) {
       studyOutputs = jsonString
     }
+    if let parameters = study.parameters,
+       let jsonData = try? JSONSerialization.data(withJSONObject: parameters, options: .prettyPrinted),
+       let jsonString = String(data: jsonData, encoding: .utf8) {
+      studyParameters = jsonString
+    }
     if !allStudies.contains(where: { $0.shortName == studyName }) {
       throw ChartIQStudyError.studyNotFound
     }
-    let script = scriptManager.getScriptForAddStudy(studyName, studyInputs: studyInputs, studyOutputs: studyOutputs)
+    let script = scriptManager.getScriptForAddStudy(studyName, studyInputs: studyInputs, studyOutputs: studyOutputs, studyParameters: studyParameters)
     webView.evaluateJavaScript(script, completionHandler: nil)
   }
 


### PR DESCRIPTION
Issues fixed.

- Match simplified addStudy method signature that Android has.
- Clear out the study id if clone is executed (a true clone of the study).
- addStudy now passes the study parameters to the script.