### PR TITLE
52680 [Documentation]: All "Requirements' on readme files for GitHub should use same language

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Contact us at <support@chartiq.com> to request sample code and guidance on how t
 - A copy of the ChartIQ JavaScript library (works best with version 9.0.1).
   - If you do not have a copy of the library or need a different version, please contact your account manager or visit our <a href="https://pages.marketintelligence.spglobal.com/ChartIQ-Follow-up-Request.html" target="_blank">Request Follow-Up Site</a>.
 
-- For previous version support, please refer to the [Releases](https://github.com/ChartIQ/ChartIQ-iOS-SDK/releases) section.
+  - For previous JavaScript version support, please refer to the [Releases](https://github.com/ChartIQ/ChartIQ-iOS-SDK/releases) section.
 
 - iOS 12.0 or later.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Contact us at <support@chartiq.com> to request sample code and guidance on how t
 
 ## Requirements
 
-- A copy of the ChartIQ JavaScript library (works best with version 9.0.1).
+- A copy of the ChartIQ JavaScript library (works best with version 9.1.2).
   - If you do not have a copy of the library or need a different version, please contact your account manager or visit our <a href="https://pages.marketintelligence.spglobal.com/ChartIQ-Follow-up-Request.html" target="_blank">Request Follow-Up Site</a>.
 
   - For previous JavaScript version support, please refer to the [Releases](https://github.com/ChartIQ/ChartIQ-iOS-SDK/releases) section.

--- a/README.md
+++ b/README.md
@@ -8,11 +8,10 @@ Contact us at <support@chartiq.com> to request sample code and guidance on how t
 
 ## Requirements
 
-- Version 9.0.1 or later of the ChartIQ library
+- A copy of the ChartIQ JavaScript library (works best with version 9.0.1).
+  - If you do not have a copy of the library or need a different version, please contact your account manager or visit our <a href="https://pages.marketintelligence.spglobal.com/ChartIQ-Follow-up-Request.html" target="_blank">Request Follow-Up Site</a>.
 
-  For previous version support, please refer to the [Releases](https://github.com/ChartIQ/ChartIQ-iOS-SDK/releases) section.
-
-  To obtain an evaluation version of the ChartIQ library, contact your account manager or visit our <a href="https://pages.marketintelligence.spglobal.com/ChartIQ-Follow-up-Request.html" target="_blank">Request Follow Up site</a> to get in contact with us!
+- For previous version support, please refer to the [Releases](https://github.com/ChartIQ/ChartIQ-iOS-SDK/releases) section.
 
 - iOS 12.0 or later.
 


### PR DESCRIPTION
## Resolves ticket [52680](https://devservices.chartiq.com/kanbanize/52680).

Brief description of Changes:
- Updated the Requirements section of the README so that the same verbiage is used across all libraries. 
