### PR TITLE
53179 Use original quote simulator url

### DIFF
--- a/Demo/ChartIQDemo.xcodeproj/project.pbxproj
+++ b/Demo/ChartIQDemo.xcodeproj/project.pbxproj
@@ -1591,7 +1591,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.6;
+				MARKETING_VERSION = 3.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.chartiq.TechnicalAnalysisChart;
 				PRODUCT_MODULE_NAME = ChartIQDemo;
 				PRODUCT_NAME = ChartIQDemo;
@@ -1620,7 +1620,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.6;
+				MARKETING_VERSION = 3.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.chartiq.TechnicalAnalysisChart;
 				PRODUCT_MODULE_NAME = ChartIQDemo;
 				PRODUCT_NAME = ChartIQDemo;

--- a/Demo/SharedDemo/Constants/Const.swift
+++ b/Demo/SharedDemo/Constants/Const.swift
@@ -128,7 +128,7 @@ public struct Const {
   // MARK: - Services
 
   struct DataSimulatorService {
-    static let simulatorUrlFormatString = "https://mobile-simulator.chartiq.com/datafeed" +
+    static let simulatorUrlFormatString = "https://simulator.chartiq.com/datafeed" +
       "?identifier=%@" + "&startdate=%@" + "%@" + "&interval=%@" + "&period=%i" + "&extended=1" + "&session=%@"
     static let simulatorEndDateFormatString = "&enddate=%@"
 


### PR DESCRIPTION
Switch to the original quote simulator url to immediately address expired secure certificate and deprecate the mobile simulator.