### PR TITLE
52738-arabic-locale-issues

### DIFF
--- a/Demo/SharedDemo/Constants/Const.swift
+++ b/Demo/SharedDemo/Constants/Const.swift
@@ -119,7 +119,7 @@ public struct Const {
     static let japaneseLanguageCode = "ja-JP"
 
     static let arabicLanguageName = "Arabic"
-    static let arabicLanguageCode = "ar-EG"
+    static let arabicLanguageCode = "ar-EG-u-nu-latn" // "ar-EG"
 
     static let languageChangedNotification = NSNotification.Name(rawValue: languageChangedNotificationName)
     static let baseLanguageModel = LanguageModel(name: englishLanguageName, languageCode: englishLanguageCode)


### PR DESCRIPTION
https://chartiq.kanbanize.com/ctrl_board/15/cards/52738/details/

Change the locale from 'ar-EG' to 'ar-EG-u-nu-latn' to address the x-axis date format issues and the y-axis number display for Arabic
