### PR TITLE
53975 incorrect arrow drawing tool name

### DIFF
--- a/Source/ChartIQDrawingToolEnums.swift
+++ b/Source/ChartIQDrawingToolEnums.swift
@@ -133,7 +133,7 @@ import Foundation
     case .annotation:
       return "annotation"
     case .arrow:
-      return "arrow"
+      return "arrowline"
     case .average:
       return "average"
     case .callout:
@@ -380,7 +380,7 @@ import Foundation
   public init?(stringValue: String) {
     let dictionary: [String: ChartIQDrawingTool] = [
       "annotation": .annotation,
-      "arrow": .arrow,
+      "arrowline": .arrow,
       "average": .average,
       "callout": .callout,
       "channel": .channel,


### PR DESCRIPTION
Update arrow tool to correct name listed in ChartIQ SDK.

Fixed when arrow tool and settings can be set on the chart. 